### PR TITLE
Changes cluster-local-vms to use 'control_plane'

### DIFF
--- a/cluster-local-vms/inventory
+++ b/cluster-local-vms/inventory
@@ -1,5 +1,5 @@
 [kube]
-kube1 ansible_host=192.168.7.2 kubernetes_role=master
+kube1 ansible_host=192.168.7.2 kubernetes_role=control_plane
 kube2 ansible_host=192.168.7.3 kubernetes_role=node
 kube3 ansible_host=192.168.7.4 kubernetes_role=node
 


### PR DESCRIPTION
The geerlingguy.kubernetes Ansible Galaxy role changed references from 'master' to 'control_plane' in this commit https://github.com/geerlingguy/ansible-role-kubernetes/commit/926a8c909e71ab71c8581c28828ac010929bc6e3. Updating local cluster VMs similarly so that it works without having to edit inventory file.