### PR TITLE
fix: update driver in molecule.yml to 'default' for Molecule 25.x com…

### DIFF
--- a/testing-molecule-kind/molecule/default/molecule.yml
+++ b/testing-molecule-kind/molecule/default/molecule.yml
@@ -1,6 +1,6 @@
 ---
 driver:
-  name: delegated
+  name: default
 lint: |
   set -e
   yamllint .


### PR DESCRIPTION
Replaced delegated driver with default as delegated is no longer supported in Molecule 25.x and above.

Ensures compatibility with the latest Molecule version and prevents runtime errors.